### PR TITLE
Fix/maksu 42 cancel action fix

### DIFF
--- a/app/code/Piimega/Maksuturva/Controller/Index/Cancel.php
+++ b/app/code/Piimega/Maksuturva/Controller/Index/Cancel.php
@@ -18,11 +18,6 @@ class Cancel extends \Piimega\Maksuturva\Controller\Maksuturva
         $payment = $this->getPayment();
         $additional_data = $payment->getAdditionalData();
 
-        if(!$this->validateReturnedOrder($order, $params)){
-            $this->_redirect('maksuturva/index/error', array('type' => \Piimega\Maksuturva\Model\PaymentAbstract::ERROR_VALUES_MISMATCH, 'message' => __('Unknown error on maksuturva payment module.')));
-            return;
-        }
-
         if ($additional_data[\Piimega\Maksuturva\Model\PaymentAbstract::MAKSUTURVA_TRANSACTION_ID] !== $pmt_id) {
             $this->_redirect('checkout');
             return;

--- a/app/code/Piimega/Maksuturva/Controller/Index/Cancel.php
+++ b/app/code/Piimega/Maksuturva/Controller/Index/Cancel.php
@@ -19,7 +19,7 @@ class Cancel extends \Piimega\Maksuturva\Controller\Maksuturva
         $additional_data = json_decode($payment->getAdditionalData(), true);
 
         if ($additional_data[\Piimega\Maksuturva\Model\PaymentAbstract::MAKSUTURVA_TRANSACTION_ID] !== $pmt_id) {
-            $this->_redirect('checkout');
+            $this->_redirect('checkout/cart');
             return;
         }
 
@@ -39,10 +39,10 @@ class Cancel extends \Piimega\Maksuturva\Controller\Maksuturva
             $this->messageManager->addError(__('You have cancelled your payment in Maksuturva.'));
         } else {
             $this->messageManager->addError(__('Unable to cancel order that has already been paid.'));
-            $this->_redirect('checkout');
+            $this->_redirect('checkout/cart');
             return;
         }
-        $this->_redirect('checkout');
+        $this->_redirect('checkout/cart');
     }
 
 }

--- a/app/code/Piimega/Maksuturva/Controller/Index/Cancel.php
+++ b/app/code/Piimega/Maksuturva/Controller/Index/Cancel.php
@@ -16,7 +16,7 @@ class Cancel extends \Piimega\Maksuturva\Controller\Maksuturva
 
         $order = $this->getLastedOrder();
         $payment = $this->getPayment();
-        $additional_data = $payment->getAdditionalData();
+        $additional_data = json_decode($payment->getAdditionalData(), true);
 
         if ($additional_data[\Piimega\Maksuturva\Model\PaymentAbstract::MAKSUTURVA_TRANSACTION_ID] !== $pmt_id) {
             $this->_redirect('checkout');


### PR DESCRIPTION
MAKSU-42

**PROBLEM:**
When user cancels order and is returned back to cancel action, cancellation always fails.
Order is not canceled and user is redirected to cart via error action.

**EXPECTED RESULT:**
When user cancels order and is returned back to cancel action, cancellation is successful:
order is cancelled and user is returned to shopping cart with proper error message

**CHANGES INTRODUCED:**
* Remove validation against pmt_reference (validateReturnedOrder) as cancel return call never contains that parameter causing validation always fail
* Add missing json_decode for payment additional data
* Redirect to cart instead of checkout for consistency and due to the fact that Magento hides error messages in checkout (https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Checkout/view/frontend/layout/checkout_index_index.xml#L449)