### PR TITLE
MAKSU-49: Add maksuturva_pmt_id field to sales_order_payment

### DIFF
--- a/app/code/Svea/Maksuturva/Controller/Index/Success.php
+++ b/app/code/Svea/Maksuturva/Controller/Index/Success.php
@@ -19,14 +19,12 @@ class Success extends \Svea\Maksuturva\Controller\Maksuturva
         \Magento\Sales\Model\OrderRepository $orderRepository,
         \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder,
         \Magento\Framework\Api\SortOrderBuilder $sortOrderBuilder,
-        \Magento\Sales\Api\OrderPaymentRepositoryInterface $orderPaymentRepository,
         array $data = []
     )
     {
         parent::__construct($context, $orderFactory, $scopeConfig, $quoteRepository, $checkoutsession, $maksuturvaHelper, $orderRepository, $searchCriteriaBuilder, $sortOrderBuilder, $data);
         $this->_resultPageFactory = $resultLayoutFactory;
         $this->orderSender = $orderSender;
-        $this->_orderPaymentRepository = $orderPaymentRepository;
     }
 
     public function execute()

--- a/app/code/Svea/Maksuturva/Controller/Index/Success.php
+++ b/app/code/Svea/Maksuturva/Controller/Index/Success.php
@@ -5,7 +5,6 @@ class Success extends \Svea\Maksuturva\Controller\Maksuturva
 {
     protected $orderSender;
     protected $_resultPageFactory;
-    protected $_orderPaymentRepository;
 
     public function __construct(
         \Magento\Framework\App\Action\Context $context,

--- a/app/code/Svea/Maksuturva/Controller/Index/Success.php
+++ b/app/code/Svea/Maksuturva/Controller/Index/Success.php
@@ -51,7 +51,7 @@ class Success extends \Svea\Maksuturva\Controller\Maksuturva
             return;
         }
 
-        $this->checkoutSession
+        $this->_checkoutSession
             ->setLastOrderId($order->getId())
             ->setLastQuoteId($order->getQuoteId())
             ->setLastSuccessQuoteId($order->getQuoteId())

--- a/app/code/Svea/Maksuturva/Controller/Index/Success.php
+++ b/app/code/Svea/Maksuturva/Controller/Index/Success.php
@@ -47,7 +47,7 @@ class Success extends \Svea\Maksuturva\Controller\Maksuturva
             $order = $this->getOrderByPaymentId($values['pmt_id']);
         } catch (\Exception $e) {
             $this->_maksuturvaHelper->maksuturvaLogger($e);
-            $this->_redirect('maksuturva/index/error', array('type' => \Piimega\Maksuturva\Model\PaymentAbstract::ERROR_VALUES_MISMATCH, 'message' => __('Order matching the payment id could not be found.')));
+            $this->_redirect('maksuturva/index/error', array('type' => \Svea\Maksuturva\Model\PaymentAbstract::ERROR_VALUES_MISMATCH, 'message' => __('Order matching the payment id could not be found.')));
             return;
         }
 

--- a/app/code/Svea/Maksuturva/Controller/Maksuturva.php
+++ b/app/code/Svea/Maksuturva/Controller/Maksuturva.php
@@ -3,6 +3,7 @@ namespace Svea\Maksuturva\Controller;
 
 use Magento\Framework\Api\SortOrder;
 use Svea\Maksuturva\Model\Gateway\Exception;
+use Svea\Maksuturva\Setup\UpgradeSchema;
 
 abstract class Maksuturva extends \Magento\Framework\App\Action\Action
 {

--- a/app/code/Svea/Maksuturva/Controller/Maksuturva.php
+++ b/app/code/Svea/Maksuturva/Controller/Maksuturva.php
@@ -32,6 +32,7 @@ abstract class Maksuturva extends \Magento\Framework\App\Action\Action
     protected $orderRepository;
     protected $searchCriteriaBuilder;
     protected $sortOrderBuilder;
+    protected $_orderPaymentRepository;
 
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
@@ -43,6 +44,7 @@ abstract class Maksuturva extends \Magento\Framework\App\Action\Action
         \Magento\Sales\Model\OrderRepository $orderRepository,
         \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder,
         \Magento\Framework\Api\SortOrderBuilder $sortOrderBuilder,
+        \Magento\Sales\Api\OrderPaymentRepositoryInterface $orderPaymentRepository,
         array $data = []
     ) 
     {
@@ -55,6 +57,7 @@ abstract class Maksuturva extends \Magento\Framework\App\Action\Action
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->_orderFactory = $orderFactory;
         $this->sortOrderBuilder = $sortOrderBuilder;
+        $this->_orderPaymentRepository = $orderPaymentRepository;
     }
 
     protected function _createInvoice($order)

--- a/app/code/Svea/Maksuturva/Controller/Maksuturva.php
+++ b/app/code/Svea/Maksuturva/Controller/Maksuturva.php
@@ -111,6 +111,30 @@ abstract class Maksuturva extends \Magento\Framework\App\Action\Action
         return $this;
     }
 
+    /**
+     * @param $paymentId
+     * @return \Magento\Sales\Api\Data\OrderInterface
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    protected function getOrderByPaymentId($paymentId)
+    {
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter(UpgradeSchema::COLUMN_MAKSUTURVA_PMT_ID, $paymentId)
+            ->create();
+
+        $payments = $this->orderPaymentRepository->getList($searchCriteria)->getItems();
+
+        if(empty($payments)) {
+            throw new \Magento\Framework\Exception\NoSuchEntityException(__('Payment with id %1 not found', $paymentId));
+        }
+
+        $payment = reset($payments);
+        $order = $this->orderRepository->get($payment->getParentId());
+
+        return $order;
+    }
+
     public function getLastedOrder()
     {
         if(!$this->_checkoutSession->getLastRealOrderId()){

--- a/app/code/Svea/Maksuturva/Controller/Maksuturva.php
+++ b/app/code/Svea/Maksuturva/Controller/Maksuturva.php
@@ -32,7 +32,7 @@ abstract class Maksuturva extends \Magento\Framework\App\Action\Action
     protected $orderRepository;
     protected $searchCriteriaBuilder;
     protected $sortOrderBuilder;
-    protected $_orderPaymentRepository;
+    protected $orderPaymentRepository;
 
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
@@ -57,7 +57,7 @@ abstract class Maksuturva extends \Magento\Framework\App\Action\Action
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->_orderFactory = $orderFactory;
         $this->sortOrderBuilder = $sortOrderBuilder;
-        $this->_orderPaymentRepository = $orderPaymentRepository;
+        $this->orderPaymentRepository = $orderPaymentRepository;
     }
 
     protected function _createInvoice($order)

--- a/app/code/Svea/Maksuturva/Model/Gateway/Implementation.php
+++ b/app/code/Svea/Maksuturva/Model/Gateway/Implementation.php
@@ -279,6 +279,7 @@ class Implementation extends \Svea\Maksuturva\Model\Gateway\Base
                 $pmt_id = $this->helper->generatePaymentId();
                 $additional_data[\Svea\Maksuturva\Model\PaymentAbstract::MAKSUTURVA_TRANSACTION_ID] = $pmt_id;
                 $payment->setAdditionalData($this->helper->getSerializer()->serialize($additional_data));
+                $payment->setMaksuturvaPmtId($pmt_id);
                 $payment->save();
             }
             $refernceNumber = $this->helper->getPmtReferenceNumber($order->getIncrementId() + 100);

--- a/app/code/Svea/Maksuturva/Setup/UpgradeSchema.php
+++ b/app/code/Svea/Maksuturva/Setup/UpgradeSchema.php
@@ -28,6 +28,44 @@ class UpgradeSchema implements \Magento\Framework\Setup\UpgradeSchemaInterface{
 
             $setup->getConnection()->createTable($fileTable);
         }
+
+        if (version_compare($context->getVersion(), '1.0.3', '<')) {
+            $this->addMaksuturvaIdForPayment($setup);
+        }
+
         $setup->endSetup();
     }
+
+    /**
+     * Add maksuturva_pmt_id for sales_order_payment
+     *
+     * @param SchemaSetupInterface $setup
+     */
+    protected function addMaksuturvaIdForPayment($setup)
+    {
+        $connection = $setup->getConnection();
+
+        $paymentTable = $setup->getTable(self::TABLE_ORDER_PAYMENT);
+        if (!$connection->tableColumnExists($paymentTable, self::COLUMN_MAKSUTURVA_PMT_ID)) {
+            $connection->addColumn(
+                $paymentTable,
+                self::COLUMN_MAKSUTURVA_PMT_ID,
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'length' => 255,
+                    'nullable' => true,
+                    'comment' => 'Maksuturva payment id'
+                ]
+            );
+
+            $setup->getConnection()->addIndex(
+                $setup->getTable(self::TABLE_ORDER_PAYMENT),
+                $setup->getIdxName($setup->getTable(self::TABLE_ORDER_PAYMENT), [self::COLUMN_MAKSUTURVA_PMT_ID]),
+                self::COLUMN_MAKSUTURVA_PMT_ID,
+                \Magento\Framework\DB\Adapter\AdapterInterface::INDEX_TYPE_INDEX
+            );
+
+        }
+    }
+
 }

--- a/app/code/Svea/Maksuturva/Setup/UpgradeSchema.php
+++ b/app/code/Svea/Maksuturva/Setup/UpgradeSchema.php
@@ -6,7 +6,10 @@ use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\DB\Ddl\Table;
 
-class UpgradeSchema implements \Magento\Framework\Setup\UpgradeSchemaInterface{
+class UpgradeSchema implements \Magento\Framework\Setup\UpgradeSchemaInterface {
+
+    const TABLE_ORDER_PAYMENT = 'sales_order_payment';
+    const COLUMN_MAKSUTURVA_PMT_ID = 'maksuturva_pmt_id';
 
     public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context){
         ini_set('display_errors', 1);

--- a/app/code/Svea/Maksuturva/etc/module.xml
+++ b/app/code/Svea/Maksuturva/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Svea_Maksuturva" setup_version="1.0.2">
+    <module name="Svea_Maksuturva" setup_version="1.0.3">
         <sequence>
             <module name="Magento_Sales" />
             <module name="Magento_Payment" />


### PR DESCRIPTION
Fixes issue with Svea/Maksuturva module success return handling. Previously utilised session data to fetch order. This does not work with server-to-server calls (“status OK callback”).

This change adds new (indexed) field to sales_order_payment called maksuturva_pmt_id. When return call is made to success end point (either by user return or server-to-server call), new logic utilises pmt_id parameter from the response and fetches payment and further more order based on that id.