### PR TITLE
MAKSU-54 Added check in case methods are empty, hiding payment method

### DIFF
--- a/app/code/Svea/Maksuturva/Model/PaymentAbstract.php
+++ b/app/code/Svea/Maksuturva/Model/PaymentAbstract.php
@@ -189,7 +189,8 @@ abstract class PaymentAbstract extends \Magento\Payment\Model\Method\AbstractMet
                 }
             }
         }
-        return $this->_methods;
+        
+        return $this->_methods ?: [];
     }
 
     public function canUseCheckout()

--- a/app/code/Svea/MaksuturvaBase/Model/Base.php
+++ b/app/code/Svea/MaksuturvaBase/Model/Base.php
@@ -15,4 +15,13 @@ class Base extends \Svea\Maksuturva\Model\PaymentAbstract
     {
         return $this->getConfigData('title');
     }
+
+    /**
+     * @param \Magento\Quote\Api\Data\CartInterface|null $quote
+     * @return bool
+     */
+    public function isAvailable(\Magento\Quote\Api\Data\CartInterface $quote = null)
+    {
+        return !empty($this->_getPaymentMethods());
+    }
 }


### PR DESCRIPTION
Fixes an issue which happened when the API was down on the checkout page. Also hides payment method, in case API is unavailable.