### PR TITLE
Feature/handling fee

### DIFF
--- a/app/code/Svea/Maksuturva/Api/HandlingFeeApplierInterface.php
+++ b/app/code/Svea/Maksuturva/Api/HandlingFeeApplierInterface.php
@@ -1,0 +1,14 @@
+<?php
+namespace Svea\Maksuturva\Api;
+
+use Magento\Quote\Model\Quote;
+
+interface HandlingFeeApplierInterface
+{
+    /**
+     * @param mixed $paymentMethod
+     * @param Quote $quote
+     * @return mixed
+     */
+    public function updateHandlingFee($paymentMethod, $quote);
+}

--- a/app/code/Svea/Maksuturva/Block/Adminhtml/Sales/HandlingFee.php
+++ b/app/code/Svea/Maksuturva/Block/Adminhtml/Sales/HandlingFee.php
@@ -1,0 +1,97 @@
+<?php
+namespace Svea\Maksuturva\Block\Adminhtml\Sales;
+
+use Magento\Framework\DataObjectFactory;
+use Magento\Framework\View\Element\Template;
+use Magento\Sales\Api\Data\CreditmemoInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+
+class HandlingFee extends \Magento\Framework\View\Element\Template
+{
+    /**
+     * @var OrderInterface
+     */
+    private $order;
+
+    /**
+     * @var DataObjectFactory
+     */
+    private $objectFactory;
+
+    /**
+     * HandlingFee constructor.
+     * @param Template\Context $context
+     * @param DataObjectFactory $objectFactory
+     * @param array $data
+     */
+    public function __construct(
+        Template\Context $context,
+        DataObjectFactory $objectFactory,
+        array $data = []
+    ) {
+        $this->objectFactory = $objectFactory;
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * @return bool
+     */
+    public function displayFullSummary()
+    {
+        return true;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getStore()
+    {
+        return $this->order->getStore();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOrder()
+    {
+        return $this->order;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLabelProperties()
+    {
+        return $this->getParentBlock()->getLabelProperties();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValueProperties()
+    {
+        return $this->getParentBlock()->getValueProperties();
+    }
+
+    /**
+     * @return $this
+     */
+    public function initTotals()
+    {
+        $parent = $this->getParentBlock();
+        $this->order = $parent->getOrder();
+        $handlingFee = $this->objectFactory->create();
+        $handlingFee->setData(
+            [
+                'code' => 'handling_fee',
+                'strong' => false,
+                'value' => $this->order->getHandlingFee(),
+                'base_value' => $this->order->getHandlingFee(),
+                'label' => __('Handling Fee'),
+            ]
+        );
+        $parent->addTotalBefore($handlingFee, 'grand_total');
+
+        return $this;
+    }
+}

--- a/app/code/Svea/Maksuturva/Block/Adminhtml/Sales/Order/Creditmemo/HandlingFee.php
+++ b/app/code/Svea/Maksuturva/Block/Adminhtml/Sales/Order/Creditmemo/HandlingFee.php
@@ -1,0 +1,103 @@
+<?php
+namespace Svea\Maksuturva\Block\Adminhtml\Sales\Order\Creditmemo;
+
+use Magento\Framework\DataObjectFactory;
+use Magento\Framework\View\Element\Template;
+use Magento\Sales\Api\Data\OrderInterface;
+
+class HandlingFee extends \Magento\Framework\View\Element\Template
+{
+    /**
+     * @var OrderInterface
+     */
+    private $order;
+
+    /**
+     * @var DataObjectFactory
+     */
+    private $objectFactory;
+
+    /**
+     * HandlingFee constructor.
+     * @param Template\Context $context
+     * @param DataObjectFactory $objectFactory
+     * @param array $data
+     */
+    public function __construct(
+        Template\Context $context,
+        DataObjectFactory $objectFactory,
+        array $data = []
+    ) {
+        $this->objectFactory = $objectFactory;
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * @return bool
+     */
+    public function displayFullSummary()
+    {
+        return true;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getStore()
+    {
+        return $this->order->getStore();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOrder()
+    {
+        return $this->order;
+    }
+
+    public function getCreditMemo()
+    {
+        return $this->getParentBlock()->getCreditMemo();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLabelProperties()
+    {
+        return $this->getParentBlock()->getLabelProperties();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValueProperties()
+    {
+        return $this->getParentBlock()->getValueProperties();
+    }
+
+    /**
+     * @return $this
+     */
+    public function initTotals()
+    {
+        $parent = $this->getParentBlock();
+        $this->order = $parent->getOrder();
+        $handlingFee = $this->objectFactory->create();
+        $handlingFee->setData(
+            [
+                'code' => 'handling_fee',
+                'strong' => false,
+                'value' => $this->order->getHandlingFee(),
+                'base_value' => $this->order->getHandlingFee(),
+                'label' => __('Handling Fee'),
+                'block_name' => 'handling_fee'
+            ]
+        );
+        $this->getCreditMemo()->setGrandTotal($this->order->getHandlingFee());
+        $parent->addTotalBefore($handlingFee, 'grand_total');
+
+        return $this;
+    }
+}

--- a/app/code/Svea/Maksuturva/Block/Adminhtml/Sales/Order/Invoice/HandlingFee.php
+++ b/app/code/Svea/Maksuturva/Block/Adminhtml/Sales/Order/Invoice/HandlingFee.php
@@ -1,0 +1,102 @@
+<?php
+namespace Svea\Maksuturva\Block\Adminhtml\Sales\Order\Invoice;
+
+use Magento\Framework\DataObjectFactory;
+use Magento\Framework\View\Element\Template;
+use Magento\Sales\Api\Data\OrderInterface;
+
+class HandlingFee extends \Magento\Framework\View\Element\Template
+{
+    /**
+     * @var OrderInterface
+     */
+    private $order;
+
+    /**
+     * @var DataObjectFactory
+     */
+    private $objectFactory;
+
+    /**
+     * HandlingFee constructor.
+     * @param Template\Context $context
+     * @param DataObjectFactory $objectFactory
+     * @param array $data
+     */
+    public function __construct(
+        Template\Context $context,
+        DataObjectFactory $objectFactory,
+        array $data = []
+    ) {
+        $this->objectFactory = $objectFactory;
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * @return bool
+     */
+    public function displayFullSummary()
+    {
+        return true;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getStore()
+    {
+        return $this->order->getStore();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOrder()
+    {
+        return $this->order;
+    }
+
+    public function getInvoice()
+    {
+        return $this->getParentBlock()->getInvoice();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLabelProperties()
+    {
+        return $this->getParentBlock()->getLabelProperties();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValueProperties()
+    {
+        return $this->getParentBlock()->getValueProperties();
+    }
+
+    /**
+     * @return $this
+     */
+    public function initTotals()
+    {
+        $parent = $this->getParentBlock();
+        $this->order = $parent->getOrder();
+        $handlingFee = $this->objectFactory->create();
+        $handlingFee->setData(
+            [
+                'code' => 'handling_fee',
+                'strong' => false,
+                'value' => $this->order->getHandlingFee(),
+                'base_value' => $this->order->getHandlingFee(),
+                'label' => __('Handling Fee'),
+            ]
+        );
+        $this->getInvoice()->setGrandTotal($this->order->getHandlingFee());
+        $parent->addTotalBefore($handlingFee, 'grand_total');
+
+        return $this;
+    }
+}

--- a/app/code/Svea/Maksuturva/Controller/Checkout/ApplyPaymentMethod.php
+++ b/app/code/Svea/Maksuturva/Controller/Checkout/ApplyPaymentMethod.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Svea\Maksuturva\Controller\Checkout;
+
+use Magento\Checkout\Model\Session;
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\Controller\Result\ForwardFactory;
+use Magento\Framework\View\LayoutFactory;
+use Svea\Maksuturva\Model\HandlingFeeApplier;
+
+class ApplyPaymentMethod extends Action
+{
+    /**
+     * @var ForwardFactory
+     */
+    private $resultForwardFactory;
+
+    /**
+     * @var LayoutFactory
+     */
+    private $layoutFactory;
+
+    /**
+     * @var Session
+     */
+    private $checkoutSession;
+
+    /**
+     * @var HandlingFeeApplier
+     */
+    private $handlingApplier;
+
+    /**
+     * ApplyPaymentMethod constructor.
+     * @param Context $context
+     * @param ForwardFactory $resultForwardFactory
+     * @param LayoutFactory $layoutFactory
+     * @param Session $checkoutSession
+     * @param HandlingFeeApplier $handlingApplier
+     */
+    public function __construct(
+        Context $context,
+        ForwardFactory $resultForwardFactory,
+        LayoutFactory $layoutFactory,
+        Session $checkoutSession,
+        HandlingFeeApplier $handlingApplier
+    ) {
+        $this->resultForwardFactory = $resultForwardFactory;
+        $this->layoutFactory = $layoutFactory;
+        $this->checkoutSession = $checkoutSession;
+        $this->handlingApplier = $handlingApplier;
+
+        parent::__construct($context);
+    }
+
+    /**
+     * @return \Magento\Framework\App\ResponseInterface|\Magento\Framework\Controller\ResultInterface|void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function execute()
+    {
+        $paymentMethod = $this->getRequest()->getParam('payment_method');
+        $quote = $this->checkoutSession->getQuote();
+
+        $this->handlingApplier->updateHandlingFee($paymentMethod, $quote);
+    }
+}

--- a/app/code/Svea/Maksuturva/Model/Config/Config.php
+++ b/app/code/Svea/Maksuturva/Model/Config/Config.php
@@ -3,10 +3,16 @@
 namespace Svea\Maksuturva\Model\Config;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Svea\Maksuturva\Model\ResourceModel\HandlingFeeResource;
 
 class Config
 {
-    const CAN_CANCEL_SETTLED = "maksuturva_config\maksuturva_payment\can_cancel_settled";
+    const CAN_CANCEL_SETTLED = "maksuturva_config/maksuturva_payment/can_cancel_settled";
+    const CARD_HANDLING_FEE = "payment/maksuturva_card_payment/handling_fee";
+    const COD_HANDLING_FEE = "payment/maksuturva_cod_payment/handling_fee";
+    const GENERIC_HANDLING_FEE = "payment/maksuturva_generic_payment/handling_fee";
+    const INVOICE_HANDLING_FEE = "payment\maksuturva_invoice_payment/handling_fee";
+    const PART_HANDLING_FEE = "payment/maksuturva_part_payment_payment/handling_fee";
 
     /**
      * @var ScopeConfigInterface
@@ -23,9 +29,97 @@ class Config
         $this->scopeConfig = $scopeConfig;
     }
 
+    /**
+     * @return bool
+     */
     public function canCancelSettled()
     {
         return $this->scopeConfig->getValue(self::CAN_CANCEL_SETTLED);
     }
 
+    /**
+     * @return array
+     */
+    public function getCardHandlingFee()
+    {
+        $value = [
+            HandlingFeeResource::CARD_PAYMENT => $this->scopeConfig->getValue(self::CARD_HANDLING_FEE)
+        ];
+
+        return $this->formatValue($value);
+    }
+
+    /**
+     * @return array
+     */
+    public function getCodHandlingFee()
+    {
+        $value = [
+            HandlingFeeResource::COD_PAYMENT => $this->scopeConfig->getValue(self::COD_HANDLING_FEE)
+        ];
+
+        return $this->formatValue($value);
+    }
+
+    /**
+     * @return array
+     */
+    public function getGenericHandlingFee()
+    {
+        $value = [
+            HandlingFeeResource::GENERIC_PAYMENT => $this->scopeConfig->getValue(self::GENERIC_HANDLING_FEE)
+        ];
+
+        return $this->formatValue($value);
+    }
+
+    /**
+     * @return array
+     */
+    public function getInvoiceHandlingFee()
+    {
+        $value = [
+            HandlingFeeResource::INVOICE_PAYMENT => $this->scopeConfig->getValue(self::INVOICE_HANDLING_FEE)
+        ];
+
+        return $this->formatValue($value);
+    }
+
+    /**
+     * @return array
+     */
+    public function getPartHandlingFee()
+    {
+        $value = [
+            HandlingFeeResource::PART_PAYMENT => $this->scopeConfig->getValue(self::PART_HANDLING_FEE)
+        ];
+
+        return $this->formatValue($value);
+    }
+
+    /**
+     * @return false|string[]
+     */
+    public function getHandlingFee()
+    {
+        $value = array_merge(
+            $this->getCardHandlingFee(),
+            $this->getCodHandlingFee(),
+            $this->getGenericHandlingFee(),
+            $this->getInvoiceHandlingFee(),
+            $this->getPartHandlingFee()
+        );
+
+        return \array_filter($value);
+    }
+
+    /**
+     * Formats the semi colon separated config values as an array
+     * @param $value
+     * @return array
+     */
+    private function formatValue($value)
+    {
+        return array_map('trim', $value);
+    }
 }

--- a/app/code/Svea/Maksuturva/Model/Creditmemo/Total/HandlingFee.php
+++ b/app/code/Svea/Maksuturva/Model/Creditmemo/Total/HandlingFee.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Svea\Maksuturva\Model\Creditmemo\Total;
+
+use Magento\Sales\Model\Order\Creditmemo\Total\AbstractTotal;
+
+class HandlingFee extends AbstractTotal
+{
+    /**
+     * @param \Magento\Sales\Model\Order\Creditmemo $creditmemo
+     * @return $this
+     */
+    public function collect(\Magento\Sales\Model\Order\Creditmemo $creditmemo)
+    {
+        $order = $creditmemo->getOrder();
+        $orderHandlingFee = $order->getHandlingFee();
+        $allowedAmount = $orderHandlingFee - $order->getRefundedHandlingFee();
+        $desiredAmount = round($creditmemo->getBaseHandlingFee(), 2);
+
+        // Note: ($x > $y + 0.0001) means ($x >= $y) for floats
+        if ($desiredAmount > round($allowedAmount) + 0.0001) {
+            $allowedAmount = $order->getBaseCurrency()->format($allowedAmount, null, false);
+            throw new \Magento\Framework\Exception\LocalizedException(
+                \__('Maximum handling fee amount allowed to refund is: %1', $allowedAmount)
+            );
+        }
+
+        $creditmemo->setHandlingFee($allowedAmount);
+        $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $allowedAmount);
+        $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $desiredAmount);
+
+        return $this;
+    }
+}

--- a/app/code/Svea/Maksuturva/Model/Gateway/Implementation.php
+++ b/app/code/Svea/Maksuturva/Model/Gateway/Implementation.php
@@ -269,6 +269,22 @@ class Implementation extends \Svea\Maksuturva\Model\Gateway\Base
             $totalSellerCosts += $shippingCost + $shippingTax;
             array_push($products_rows, $row);
 
+            $handlingFee = $order->getHandlingFee();
+
+            //Row type 3
+            $row = [
+                'pmt_row_name' => \__('Handling Fee'),
+                'pmt_row_desc' => \__('Added handling fee to total'),
+                'pmt_row_quantity' => 1,
+                'pmt_row_deliverydate' => date("d.m.Y"),
+                'pmt_row_price_net' => str_replace('.', ',', sprintf("%.2f", $handlingFee)),
+                'pmt_row_vat' => "0,00",
+                'pmt_row_discountpercentage' => "0,00",
+                'pmt_row_type' => 3
+            ];
+            $totalSellerCosts += $handlingFee;
+            $products_rows[] = $row;
+
             $options = array();
             $options["pmt_keygeneration"] = $this->keyVersion;
 

--- a/app/code/Svea/Maksuturva/Model/HandlingFeeApplier.php
+++ b/app/code/Svea/Maksuturva/Model/HandlingFeeApplier.php
@@ -1,0 +1,38 @@
+<?php
+namespace Svea\Maksuturva\Model;
+
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\QuoteRepository;
+use Svea\Maksuturva\Api\HandlingFeeApplierInterface;
+
+class HandlingFeeApplier implements HandlingFeeApplierInterface
+{
+    /**
+     * @var QuoteRepository
+     */
+    private $quoteRepository;
+
+    /**
+     * HandlingFeeApplier constructor.
+     * @param QuoteRepository $quoteRepository
+     */
+    public function __construct(
+        QuoteRepository $quoteRepository
+    ) {
+        $this->quoteRepository = $quoteRepository;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateHandlingFee($paymentMethod, $quote)
+    {
+        if (isset($paymentMethod['method'])) {
+            $quote->getPayment()->setMethod($paymentMethod['method']);
+        }
+        $quote->unsTotalsCollectedFlag();
+        $quote->collectTotals();
+        $quote->setTriggerRecollect(true);
+        $this->quoteRepository->save($quote);
+    }
+}

--- a/app/code/Svea/Maksuturva/Model/Invoice/Total/HandlingFee.php
+++ b/app/code/Svea/Maksuturva/Model/Invoice/Total/HandlingFee.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Svea\Maksuturva\Model\Invoice\Total;
+
+use Magento\Sales\Model\Order\Invoice\Total\AbstractTotal;
+
+class HandlingFee extends AbstractTotal
+{
+    /**
+     * @param \Magento\Sales\Model\Order\Invoice $invoice
+     * @return $this
+     */
+    public function collect(\Magento\Sales\Model\Order\Invoice $invoice)
+    {
+        $invoice->setHandlingFee(0);
+
+        $amount = $invoice->getOrder()->getHandlingFee();
+        $invoice->setHandlingFee($amount);
+
+        $invoice->setGrandTotal($invoice->getGrandTotal() + $invoice->getHandlingFee());
+        $invoice->setBaseGrandTotal($invoice->getBaseGrandTotal() + $invoice->getHandlingFee());
+
+        return $this;
+    }
+}

--- a/app/code/Svea/Maksuturva/Model/Observer/SaveMaksuturvaPreselectedPaymentMethod.php
+++ b/app/code/Svea/Maksuturva/Model/Observer/SaveMaksuturvaPreselectedPaymentMethod.php
@@ -17,6 +17,10 @@ class SaveMaksuturvaPreselectedPaymentMethod implements \Magento\Framework\Event
         }else{
             $order->setMaksuturvaPreselectedPaymentMethod('');
         }
+
+        $handlingFee = $quote->getHandlingFee();
+        $order->setHandlingFee($handlingFee);
+
         return $this;
     }
 }

--- a/app/code/Svea/Maksuturva/Model/Order/CreditMemoFactory.php
+++ b/app/code/Svea/Maksuturva/Model/Order/CreditMemoFactory.php
@@ -1,0 +1,31 @@
+<?php
+namespace Svea\Maksuturva\Model\Order;
+
+use Magento\Sales\Model\Order\Creditmemo;
+
+class CreditMemoFactory extends \Magento\Sales\Model\Order\CreditmemoFactory
+{
+    /**
+     * Initialize creditmemo state based on requested parameters
+     *
+     * @param Creditmemo $creditmemo
+     * @param array $data
+     * @return void
+     */
+    protected function initData($creditmemo, $data)
+    {
+        if (isset($data['shipping_amount'])) {
+            $creditmemo->setBaseShippingAmount((double)$data['shipping_amount']);
+            $creditmemo->setBaseShippingInclTax((double)$data['shipping_amount']);
+        }
+        if (isset($data['adjustment_positive'])) {
+            $creditmemo->setAdjustmentPositive($data['adjustment_positive']);
+        }
+        if (isset($data['adjustment_negative'])) {
+            $creditmemo->setAdjustmentNegative($data['adjustment_negative']);
+        }
+        if (isset($data['handling_fee'])) {
+            $creditmemo->setBaseHandlingFee($data['handling_fee']);
+        }
+    }
+}

--- a/app/code/Svea/Maksuturva/Model/Quote/Total/HandlingFee.php
+++ b/app/code/Svea/Maksuturva/Model/Quote/Total/HandlingFee.php
@@ -1,0 +1,102 @@
+<?php
+namespace Svea\Maksuturva\Model\Quote\Total;
+
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Api\Data\ShippingAssignmentInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address\Total;
+use Magento\Quote\Model\Quote\Address\Total\AbstractTotal;
+use Svea\Maksuturva\Model\Config\Config;
+use Svea\Maksuturva\Model\ResourceModel\HandlingFeeResource;
+
+class HandlingFee extends AbstractTotal
+{
+    const CODE = 'handling_fee';
+
+    /**
+     * @var Config
+     */
+    private $configProvider;
+
+    /**
+     * HandlingFee constructor.
+     * @param Config $configProvider
+     */
+    public function __construct(
+        Config $configProvider
+    ) {
+        $this->configProvider = $configProvider;
+        $this->setCode(self::CODE);
+    }
+
+    /**
+     * @param Quote $quote
+     * @param ShippingAssignmentInterface $shippingAssignment
+     * @param Total $total
+     * @return $this
+     */
+    public function collect(
+        Quote $quote,
+        ShippingAssignmentInterface $shippingAssignment,
+        Total $total
+    ) {
+        parent::collect($quote, $shippingAssignment, $total);
+
+        $items = $shippingAssignment->getItems();
+        if (empty($items)) {
+            return $this;
+        }
+
+        $handlingFee = $this->calculateHandlingFee($quote, $total);
+
+        $quote->setData(HandlingFeeResource::HANDLING_FEE, $handlingFee);
+        $quote->setData(HandlingFeeResource::BASE_HANDLING_FEE, $handlingFee);
+
+        $total->setData(HandlingFeeResource::HANDLING_FEE, $handlingFee);
+        $total->setData(HandlingFeeResource::BASE_HANDLING_FEE, $handlingFee);
+        $total->setTotalAmount(self::CODE, $handlingFee);
+        $total->setBaseTotalAmount(self::CODE, $handlingFee);
+
+        return $this;
+    }
+
+    /**
+     * @param CartInterface $quote
+     * @param Total $total
+     * @return float
+     */
+    private function calculateHandlingFee(CartInterface $quote, Total $total)
+    {
+        $paymentCode = $quote->getPayment()->getMethod();
+        $handlingFeeConfig = $this->configProvider->getHandlingFee();
+        foreach ($handlingFeeConfig as $key => $fee) {
+            if ($key == $paymentCode) {
+                return $fee;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param Quote $quote
+     * @param Total $total
+     * @return array
+     */
+    public function fetch(\Magento\Quote\Model\Quote $quote, \Magento\Quote\Model\Quote\Address\Total $total)
+    {
+        return [
+            'code' => $this->getCode(),
+            'title' => $this->getLabel(),
+            'value' => $this->calculateHandlingFee($quote, $total)
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getLabel()
+    {
+        return \__('Handling Fee');
+    }
+}

--- a/app/code/Svea/Maksuturva/Model/ResourceModel/HandlingFeeResource.php
+++ b/app/code/Svea/Maksuturva/Model/ResourceModel/HandlingFeeResource.php
@@ -1,0 +1,79 @@
+<?php
+namespace Svea\Maksuturva\Model\ResourceModel;
+
+use Magento\Framework\App\ResourceConnection;
+
+class HandlingFeeResource
+{
+    const QUOTE_ID = 'entity_id';
+    const HANDLING_FEE = 'handling_fee';
+    const BASE_HANDLING_FEE = 'base_handling_fee';
+    const PAYMENT_CODE = 'payment_code';
+    const CARD_PAYMENT = 'maksuturva_card_payment';
+    const COD_PAYMENT = 'maksuturva_cod_payment';
+    const GENERIC_PAYMENT = 'maksuturva_generic_payment';
+    const INVOICE_PAYMENT = 'maksuturva_invoice_payment';
+    const PART_PAYMENT = 'maksuturva_part_payment_payment';
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var \Magento\Framework\DB\Adapter\AdapterInterface
+     */
+    private $connection;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection
+    ) {
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * @param int $quoteId
+     * @return float
+     */
+    public function getHandlingFee(int $quoteId)
+    {
+        $connection = $this->getConnection();
+        $select = $connection->select()
+            ->from('quote', self::HANDLING_FEE)
+            ->where('entity_id = ?', $quoteId);
+
+        return (float)$connection->fetchOne($select);
+    }
+
+    /**
+     * @param int $quoteId
+     * @param float $handlingFee
+     * @return void
+     */
+    public function setHandlingFee(int $quoteId, float $handlingFee)
+    {
+        $connection = $this->getConnection();
+        $connection->update(
+            'quote',
+            [
+                self::HANDLING_FEE => $handlingFee,
+            ],
+            \sprintf('entity_id = \'%s\'', $quoteId)
+        );
+    }
+
+    /**
+     * @return \Magento\Framework\DB\Adapter\AdapterInterface
+     */
+    private function getConnection()
+    {
+        if ($this->connection === null) {
+            $this->connection = $this->resourceConnection->getConnection();
+        }
+
+        return $this->connection;
+    }
+}

--- a/app/code/Svea/Maksuturva/Observer/SetHandlingFeeRefund.php
+++ b/app/code/Svea/Maksuturva/Observer/SetHandlingFeeRefund.php
@@ -1,0 +1,18 @@
+<?php
+namespace Svea\Maksuturva\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class SetHandlingFeeRefund implements ObserverInterface
+{
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        $creditmemo = $observer->getEvent()->getCreditmemo();
+        $order = $creditmemo->getOrder();
+        $order->setRefundedHandlingFee($creditmemo->getBaseHandlingFee());
+    }
+}

--- a/app/code/Svea/Maksuturva/Setup/UpgradeSchema.php
+++ b/app/code/Svea/Maksuturva/Setup/UpgradeSchema.php
@@ -36,6 +36,11 @@ class UpgradeSchema implements \Magento\Framework\Setup\UpgradeSchemaInterface {
             $this->addMaksuturvaIdForPayment($setup);
         }
 
+
+        if (\version_compare($context->getVersion(), '1.0.4') < 0) {
+            $this->version104($setup);
+        }
+
         $setup->endSetup();
     }
 
@@ -70,5 +75,53 @@ class UpgradeSchema implements \Magento\Framework\Setup\UpgradeSchemaInterface {
 
         }
     }
+
+
+    /**
+     * @param \Magento\Framework\Setup\SchemaSetupInterface $setup
+     */
+    public function version104(SchemaSetupInterface $setup)
+    {
+        $connection = $setup->getConnection();
+        $tables = ['quote', 'quote_address', 'sales_order'];
+
+        foreach ($tables as $table) {
+            $connection->addColumn(
+                $setup->getTable($table),
+                'handling_fee',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
+                    'length' => '12,4',
+                    'default' => null,
+                    'nullable' => true,
+                    'comment' => 'Handling Fee Amount',
+                ]
+            );
+            $connection->addColumn(
+                $setup->getTable($table),
+                'base_handling_fee',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
+                    'length' => '12,4',
+                    'default' => null,
+                    'nullable' => true,
+                    'comment' => 'Base Handling Fee Amount',
+                ]
+            );
+        }
+
+        $connection->addColumn(
+            $setup->getTable('sales_order'),
+            'refunded_handling_fee',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
+                'length' => '12,4',
+                'default' => null,
+                'nullable' => true,
+                'comment' => 'Refunded Handling Fee',
+            ]
+        );
+    }
+
 
 }

--- a/app/code/Svea/Maksuturva/etc/adminhtml/system.xml
+++ b/app/code/Svea/Maksuturva/etc/adminhtml/system.xml
@@ -106,6 +106,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment><![CDATA[Allow the canceling of settled payments. This will be attempted, if normal canceling fails.]]></comment>
                 </field>
+
             </group>
         </section>
     </system>

--- a/app/code/Svea/Maksuturva/etc/di.xml
+++ b/app/code/Svea/Maksuturva/etc/di.xml
@@ -29,4 +29,6 @@
     </type>
     <preference for="Svea\Maksuturva\Api\MaksuturvaFormInterface" type="Svea\Maksuturva\Model\Form"/>
 
+    <preference for="Magento\Sales\Model\Order\CreditmemoFactory" type="Svea\Maksuturva\Model\Order\CreditMemoFactory"/>
+
 </config>

--- a/app/code/Svea/Maksuturva/etc/events.xml
+++ b/app/code/Svea/Maksuturva/etc/events.xml
@@ -19,4 +19,8 @@
     <event name="maksuturva_gateway_implementation_get_form_after">
         <observer name="Svea_maksuturva_gateway_implementation_get_form_after" instance="Svea\Maksuturva\Model\Observer\AddGiftCardPaymentRow" />
     </event>
+
+    <event name="sales_order_creditmemo_refund">
+        <observer name="set_refunded_handling_fee" instance="Svea\Maksuturva\Observer\SetHandlingFeeRefund" />
+    </event>
 </config>

--- a/app/code/Svea/Maksuturva/etc/sales.xml
+++ b/app/code/Svea/Maksuturva/etc/sales.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Sales:etc/sales.xsd">
+    <section name="quote">
+        <group name="totals">
+            <item name="handling_fee" instance="Svea\Maksuturva\Model\Quote\Total\HandlingFee" sort_order="100"/>
+        </group>
+    </section>
+    <section name="order_invoice">
+        <group name="totals">
+            <item name="fee" instance="Svea\Maksuturva\Model\Invoice\Total\HandlingFee" sort_order="110"/>
+        </group>
+    </section>
+    <section name="order_creditmemo">
+        <group name="totals">
+            <item name="handling_fee" instance="Svea\Maksuturva\Model\Creditmemo\Total\HandlingFee" sort_order="120"/>
+        </group>
+    </section>
+</config>

--- a/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_creditmemo_new.xml
+++ b/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_creditmemo_new.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="creditmemo_totals">
+            <block class="Svea\Maksuturva\Block\Adminhtml\Sales\Order\Creditmemo\HandlingFee"
+                   name="handling_fee"
+                   template="Svea_Maksuturva::creditmemo.phtml" />
+        </referenceBlock>
+    </body>
+</page>

--- a/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
+++ b/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="creditmemo_totals">
+            <block class="Svea\Maksuturva\Block\Adminhtml\Sales\Order\Creditmemo\HandlingFee"
+                   name="handling_fee"
+                   template="Svea_Maksuturva::creditmemo.phtml" />
+        </referenceBlock>
+    </body>
+</page>

--- a/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_creditmemo_view.xml
+++ b/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_creditmemo_view.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="creditmemo_totals">
+            <block class="Svea\Maksuturva\Block\Adminhtml\Sales\Order\Creditmemo\HandlingFee"
+                   name="handling_fee"
+                   template="Svea_Maksuturva::creditmemo_view.phtml" />
+        </referenceBlock>
+    </body>
+</page>

--- a/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_invoice_new.xml
+++ b/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_invoice_new.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="invoice_totals">
+            <block class="Svea\Maksuturva\Block\Adminhtml\Sales\Order\Invoice\HandlingFee" name="handling_fee"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_invoice_updateqty.xml
+++ b/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_invoice_updateqty.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="invoice_totals">
+            <block class="Svea\Maksuturva\Block\Adminhtml\Sales\Order\Invoice\HandlingFee" name="handling_fee"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_invoice_view.xml
+++ b/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_invoice_view.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="invoice_totals">
+            <block class="Svea\Maksuturva\Block\Adminhtml\Sales\Order\Invoice\HandlingFee" name="handling_fee"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_view.xml
+++ b/app/code/Svea/Maksuturva/view/adminhtml/layout/sales_order_view.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+
+    <body>
+        <referenceContainer name="order_totals">
+            <block class="Svea\Maksuturva\Block\Adminhtml\Sales\HandlingFee" name="handling_fee"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Svea/Maksuturva/view/adminhtml/templates/creditmemo.phtml
+++ b/app/code/Svea/Maksuturva/view/adminhtml/templates/creditmemo.phtml
@@ -1,0 +1,10 @@
+<?php $order = $block->getOrder() ?>
+
+<td class="label"><?= /* @escapeNotVerified */ \__('Handling Fee') ?><div id="handling_fee"></div></td>
+<td>
+    <input type="text"
+           name="creditmemo[handling_fee]"
+           value="<?= (float)$order->getHandlingFee() - (float)$order->getRefundedHandlingFee() ?>"
+           class="input-text admin__control-text not-negative-amount"
+           id="handling_fee" />
+</td>

--- a/app/code/Svea/Maksuturva/view/adminhtml/templates/creditmemo_view.phtml
+++ b/app/code/Svea/Maksuturva/view/adminhtml/templates/creditmemo_view.phtml
@@ -1,0 +1,10 @@
+<?php $_order = $block->getOrder() ?>
+
+<tr>
+    <td class="label">
+        <div class="summary-collapse" tabindex="0"><?= /* @escapeNotVerified */ \__('Handling Fee') ?></div>
+    </td>
+    <td>
+        <span class="price"><?= $_order->getBaseCurrency()->format((float)$_order->getHandlingFee(), null, false) ?></span>
+    </td>
+</tr>

--- a/app/code/Svea/Maksuturva/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Svea/Maksuturva/view/frontend/layout/checkout_cart_index.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="checkout.cart.totals">
+            <arguments>
+                <argument name="jsLayout" xsi:type="array">
+                    <item name="components" xsi:type="array">
+                        <item name="block-totals" xsi:type="array">
+                            <item name="children" xsi:type="array">
+                                <item name="handling_fee" xsi:type="array">
+                                    <item name="component"  xsi:type="string">Svea_Maksuturva/js/view/checkout/cart/totals/handling</item>
+                                    <item name="sortOrder" xsi:type="string">2</item>
+                                    <item name="config" xsi:type="array">
+                                        <item name="template" xsi:type="string">Svea_Maksuturva/checkout/cart/totals/handling</item>
+                                        <item name="title" xsi:type="string" translate="true">Handling Fee</item>
+                                    </item>
+                                </item>
+                            </item>
+                        </item>
+                    </item>
+                </argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/app/code/Svea/Maksuturva/view/frontend/layout/checkout_index_index.xml
+++ b/app/code/Svea/Maksuturva/view/frontend/layout/checkout_index_index.xml
@@ -7,6 +7,26 @@
                     <item name="components" xsi:type="array">
                         <item name="checkout" xsi:type="array">
                             <item name="children" xsi:type="array">
+                                <item name="sidebar" xsi:type="array">
+                                    <item name="children" xsi:type="array">
+                                        <item name="summary" xsi:type="array">
+                                            <item name="children" xsi:type="array">
+                                                <item name="totals" xsi:type="array">
+                                                    <item name="children" xsi:type="array">
+                                                        <item name="handling_fee" xsi:type="array">
+                                                            <item name="component"  xsi:type="string">Svea_Maksuturva/js/view/checkout/summary/handling</item>
+                                                            <item name="sortOrder" xsi:type="string">20</item>
+                                                            <item name="config" xsi:type="array">
+                                                                <item name="template" xsi:type="string">Svea_Maksuturva/checkout/summary/handling</item>
+                                                                <item name="title" xsi:type="string" translate="true">Handling Fee</item>
+                                                            </item>
+                                                        </item>
+                                                    </item>
+                                                </item>
+                                            </item>
+                                        </item>
+                                    </item>
+                                </item>
                                 <item name="steps" xsi:type="array">
                                     <item name="children" xsi:type="array">
                                         <item name="billing-step" xsi:type="array">

--- a/app/code/Svea/Maksuturva/view/frontend/requirejs-config.js
+++ b/app/code/Svea/Maksuturva/view/frontend/requirejs-config.js
@@ -1,0 +1,8 @@
+var config = {
+    map: {
+        '*': {
+            'Magento_Checkout/js/action/select-payment-method':
+                'Svea_Maksuturva/js/action/select-payment-method'
+        }
+    }
+};

--- a/app/code/Svea/Maksuturva/view/frontend/web/js/action/select-payment-method.js
+++ b/app/code/Svea/Maksuturva/view/frontend/web/js/action/select-payment-method.js
@@ -1,0 +1,25 @@
+define(
+    [
+        'Magento_Checkout/js/model/quote',
+        'Magento_Checkout/js/model/full-screen-loader',
+        'jquery',
+        'Magento_Checkout/js/action/get-totals',
+    ],
+    function (quote, fullScreenLoader, jQuery, getTotalsAction) {
+        'use strict';
+        return function (paymentMethod) {
+            quote.paymentMethod(paymentMethod);
+
+            fullScreenLoader.startLoader();
+
+            jQuery.ajax('/maksuturva/checkout/applyPaymentMethod', {
+                data: {payment_method: paymentMethod},
+                complete: function () {
+                    getTotalsAction([]);
+                    fullScreenLoader.stopLoader();
+                }
+            });
+
+        }
+    }
+);

--- a/app/code/Svea/Maksuturva/view/frontend/web/js/view/checkout/cart/totals/handling.js
+++ b/app/code/Svea/Maksuturva/view/frontend/web/js/view/checkout/cart/totals/handling.js
@@ -1,0 +1,22 @@
+/**
+ *  Copyright © Vaimo Group. All rights reserved.
+ *  See LICENSE_VAIMO.txt for license details.
+ */
+
+define(
+    [
+        'Svea_Maksuturva/js/view/checkout/summary/handling'
+    ],
+    function (Component) {
+        'use strict';
+
+        return Component.extend({
+            /**
+             * @override
+             */
+            isDisplayed: function () {
+                return true;
+            }
+        });
+    }
+);

--- a/app/code/Svea/Maksuturva/view/frontend/web/js/view/checkout/summary/handling.js
+++ b/app/code/Svea/Maksuturva/view/frontend/web/js/view/checkout/summary/handling.js
@@ -1,0 +1,37 @@
+/**
+ *  Copyright © Vaimo Group. All rights reserved.
+ *  See LICENSE_VAIMO.txt for license details.
+ */
+
+define([
+    'ko',
+    'Magento_Checkout/js/view/summary/abstract-total',
+    'Magento_Checkout/js/model/quote',
+    'Magento_Checkout/js/model/totals',
+], function(ko, Component, quote, totals) {
+    'use strict';
+
+    return Component.extend({
+        defaults: {
+            isFullTaxSummaryDisplayed: window.checkoutConfig.isFullTaxSummaryDisplayed || false,
+            template: 'Svea_Maksuturva/checkout/summary/handling',
+        },
+        totals: quote.getTotals(),
+        isTaxDisplayedInGrandTotal: window.checkoutConfig.includeTaxInGrandTotal || false,
+        isDisplayed: function() {
+            return true;
+        },
+        getPureValue: function() {
+            var price = 0,
+                handlingSegment = totals.getSegment('handling_fee'),
+                handlingValue = handlingSegment ? totals.getSegment('handling_fee').value : null;
+            if (this.totals() && handlingValue) {
+                price = parseFloat(handlingValue);
+            }
+            return price;
+        },
+        getValue: function() {
+            return this.getFormattedPrice(this.getPureValue());
+        }
+    });
+});

--- a/app/code/Svea/Maksuturva/view/frontend/web/js/view/payment/method-renderer/maksuturva_payment.js
+++ b/app/code/Svea/Maksuturva/view/frontend/web/js/view/payment/method-renderer/maksuturva_payment.js
@@ -11,16 +11,17 @@ define(
         'Magento_Customer/js/model/customer',
         'Magento_Checkout/js/model/payment/additional-validators',
         'Magento_Checkout/js/action/place-order',
+        'Magento_Checkout/js/model/full-screen-loader',
+        'Magento_Checkout/js/action/get-totals',
         'mage/validation'
     ],
-    function ($, ko, Component, selectPaymentMethodAction,quote, checkoutData, urlBuilder, url,customer, additionalValidators, placeOrderAction) {
+    function ($, ko, Component, selectPaymentMethodAction,quote, checkoutData, urlBuilder, url,customer, additionalValidators, placeOrderAction, fullScreenLoader, getTotalsAction) {
         'use strict';
 
         var selectedMethod = ko.observable();
+        var selectedSveaMethod = checkoutData.getSelectedPaymentMethod();
 
         return Component.extend({
-
-
             //be implemented in sub-class
             getCode: function() {},
 

--- a/app/code/Svea/Maksuturva/view/frontend/web/template/checkout/cart/totals/handling.html
+++ b/app/code/Svea/Maksuturva/view/frontend/web/template/checkout/cart/totals/handling.html
@@ -1,0 +1,14 @@
+<!--
+/**
+ * Copyright © Vaimo Group. All rights reserved.
+ * See LICENSE_VAIMO.txt for license details.
+ */
+-->
+<!-- ko if: isDisplayed() -->
+<tr class="totals maksuturva_handling_total excl">
+    <th class="mark" colspan="1" scope="row" data-bind="text: title"></th>
+    <td class="amount" data-bind="attr: {'data-th': title}">
+        <span class="price" data-bind="text: getValue()"></span>
+    </td>
+</tr>
+<!-- /ko -->

--- a/app/code/Svea/Maksuturva/view/frontend/web/template/checkout/summary/handling.html
+++ b/app/code/Svea/Maksuturva/view/frontend/web/template/checkout/summary/handling.html
@@ -1,0 +1,14 @@
+<!--
+/**
+ * Copyright © Vaimo Group. All rights reserved.
+ * See LICENSE_VAIMO.txt for license details.
+ */
+-->
+<!-- ko if: isDisplayed() -->
+<tr class="totals maksuturva_handling_total excl">
+    <th class="mark" colspan="1" scope="row" data-bind="text: title"></th>
+    <td class="amount" data-bind="attr: {'data-th': title}">
+        <span class="price" data-bind="text: getValue()"></span>
+    </td>
+</tr>
+<!-- /ko -->

--- a/app/code/Svea/MaksuturvaCard/etc/adminhtml/system.xml
+++ b/app/code/Svea/MaksuturvaCard/etc/adminhtml/system.xml
@@ -37,6 +37,11 @@
                     <source_model>Svea\Maksuturva\Model\System\Config\Source\Formtype</source_model>
                     <validate>required-entry</validate>
                 </field>
+
+                <field id="handling_fee" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Handling Fee</label>
+                    <comment><![CDATA[Input amount of handling fee which will be added to total when the payment method is selected.]]></comment>
+                </field>
             </group>
         </section>
     </system>

--- a/app/code/Svea/MaksuturvaCod/etc/adminhtml/system.xml
+++ b/app/code/Svea/MaksuturvaCod/etc/adminhtml/system.xml
@@ -37,6 +37,11 @@
                     <source_model>Svea\Maksuturva\Model\System\Config\Source\Formtype</source_model>
                     <validate>required-entry</validate>
                 </field>
+
+                <field id="handling_fee" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Handling Fee</label>
+                    <comment><![CDATA[Input amount of handling fee which will be added to total when the payment method is selected.]]></comment>
+                </field>
             </group>
         </section>
     </system>

--- a/app/code/Svea/MaksuturvaGeneric/etc/adminhtml/system.xml
+++ b/app/code/Svea/MaksuturvaGeneric/etc/adminhtml/system.xml
@@ -37,6 +37,11 @@
                     <source_model>Svea\Maksuturva\Model\System\Config\Source\Formtype</source_model>
                     <validate>required-entry</validate>
                 </field>
+
+                <field id="handling_fee" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Handling Fee</label>
+                    <comment><![CDATA[Input amount of handling fee which will be added to total when the payment method is selected.]]></comment>
+                </field>
             </group>
         </section>
     </system>

--- a/app/code/Svea/MaksuturvaInvoice/etc/adminhtml/system.xml
+++ b/app/code/Svea/MaksuturvaInvoice/etc/adminhtml/system.xml
@@ -37,6 +37,11 @@
                     <source_model>Svea\Maksuturva\Model\System\Config\Source\Formtype</source_model>
                     <validate>required-entry</validate>
                 </field>
+
+                <field id="handling_fee" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Handling Fee</label>
+                    <comment><![CDATA[Input amount of handling fee which will be added to total when the payment method is selected.]]></comment>
+                </field>
             </group>
         </section>
     </system>

--- a/app/code/Svea/MaksuturvaPartPayment/etc/adminhtml/system.xml
+++ b/app/code/Svea/MaksuturvaPartPayment/etc/adminhtml/system.xml
@@ -37,6 +37,11 @@
                     <source_model>Svea\Maksuturva\Model\System\Config\Source\Formtype</source_model>
                     <validate>required-entry</validate>
                 </field>
+
+                <field id="handling_fee" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Handling Fee</label>
+                    <comment><![CDATA[Input amount of handling fee which will be added to total when the payment method is selected.]]></comment>
+                </field>
             </group>
         </section>
     </system>


### PR DESCRIPTION
This feature implements handling fee functionality for SVEA payment module

What the feature does:

This feature allows the user of the module to configure handling fee for various payment methods. Additions in this implementation:

    General:

        Admin: Handling fee is configurable per payment method

    Order:

        Handling fee is added into Magento totals/total rows when customer selects payment method

        Handling fee is exported in pmt_row_type attribute, with value 3

    Refunds

        Magento Order view: Handling fee is shown as own line

            Editable amount with default sum is the whole handling fee.

            User cannot enter bigger amount than original

        Refund logic for the handling fee, refund data exported

    Admin

        Handling fee is configurable per payment method