### PR TITLE
Increase pmt_buyeremail max field length from 40 to 100

### DIFF
--- a/app/code/Svea/Maksuturva/Model/Form.php
+++ b/app/code/Svea/Maksuturva/Model/Form.php
@@ -101,7 +101,7 @@ class Form extends \Magento\Framework\Model\AbstractModel implements \Svea\Maksu
         'pmt_buyercity' => array(1, 40),
         'pmt_buyercountry' => array(1, 2),
         'pmt_buyerphone' => array(0, 40),    // opt
-        'pmt_buyeremail' => array(0, 40),    // opt
+        'pmt_buyeremail' => array(0, 100),    // opt
         'pmt_deliveryname' => array(1, 40),
         'pmt_deliveryaddress' => array(1, 40),
         'pmt_deliverypostalcode' => array(1, 5),


### PR DESCRIPTION
Increase `pmt_buyeremail` max field length from 40 to 100 to support longer e-mail addresses. 

Currently e-mail addresses longer than 40 characters cause payment to fail.

Used max length 100, same as here https://github.com/maksuturva/magento2_payment_module/blob/master/app/code/Svea/MaksuturvaMasterpass/Model/Form/Form.php#L76