### PR TITLE
Add support for submethod handling fees

### DIFF
--- a/app/code/Svea/Maksuturva/Api/HandlingFeeApplierInterface.php
+++ b/app/code/Svea/Maksuturva/Api/HandlingFeeApplierInterface.php
@@ -8,7 +8,10 @@ interface HandlingFeeApplierInterface
     /**
      * @param mixed $paymentMethod
      * @param Quote $quote
+     * @param string|null $subMethod
+     * @param string|null $collatedMethod
+     *
      * @return mixed
      */
-    public function updateHandlingFee($paymentMethod, $quote);
+    public function updateHandlingFee($paymentMethod, $quote, $subMethod = null, $collatedMethod = null);
 }

--- a/app/code/Svea/Maksuturva/Controller/Checkout/ApplyPaymentMethod.php
+++ b/app/code/Svea/Maksuturva/Controller/Checkout/ApplyPaymentMethod.php
@@ -62,12 +62,9 @@ class ApplyPaymentMethod extends Action
     public function execute()
     {
         $paymentMethod = $this->getRequest()->getParam('payment_method');
-        $collatedPaymentMethod = $this->getRequest()->getParam('collated_method') ?? null;
+        $subMethod = $this->getRequest()->getParam('sub_payment_method') ?? null;
+        $collatedMethod = $this->getRequest()->getParam('collated_method') ?? null;
         $quote = $this->checkoutSession->getQuote();
-        if ($collatedPaymentMethod) {
-            $this->handlingApplier->updateHandlingFee($paymentMethod, $quote, $collatedPaymentMethod);
-        } else {
-            $this->handlingApplier->updateHandlingFee($paymentMethod, $quote);
-        }
+        $this->handlingApplier->updateHandlingFee($paymentMethod, $quote, $subMethod, $collatedMethod);
     }
 }

--- a/app/code/Svea/Maksuturva/Model/HandlingFeeApplier.php
+++ b/app/code/Svea/Maksuturva/Model/HandlingFeeApplier.php
@@ -25,14 +25,15 @@ class HandlingFeeApplier implements HandlingFeeApplierInterface
     /**
      * @inheritDoc
      */
-    public function updateHandlingFee($paymentMethod, $quote, $submethod = null)
+    public function updateHandlingFee($paymentMethod, $quote, $subMethod = null, $collatedMethod = null)
     {
-        if (isset($paymentMethod['method'])) {
+        if (\is_string($paymentMethod)) {
+            $quote->getPayment()->setMethod($paymentMethod);
+        } elseif (isset($paymentMethod['method'])) {
             $quote->getPayment()->setMethod($paymentMethod['method']);
         }
-        if ($submethod) {
-            $quote->getPayment()->setAdditionalInformation('collated_method', $submethod);
-        }
+        $quote->getPayment()->setAdditionalInformation('sub_payment_method', $subMethod);
+        $quote->getPayment()->setAdditionalInformation('collated_method', $collatedMethod);
         $quote->unsTotalsCollectedFlag();
         $quote->collectTotals();
         $quote->setTriggerRecollect(true);

--- a/app/code/Svea/Maksuturva/Model/ResourceModel/HandlingFeeResource.php
+++ b/app/code/Svea/Maksuturva/Model/ResourceModel/HandlingFeeResource.php
@@ -14,6 +14,7 @@ class HandlingFeeResource
     const GENERIC_PAYMENT = 'maksuturva_generic_payment';
     const INVOICE_PAYMENT = 'maksuturva_invoice_payment';
     const PART_PAYMENT = 'maksuturva_part_payment_payment';
+    const COLLATED_PAYMENT = 'maksuturva_collated_payment';
     const COLLATED_LATER_PAYMENT = 'pay_later';
     const COLLATED_NOW_PAYMENT = 'pay_now_other';
     const COLLATED_BANK_PAYMENT = 'pay_now_bank';

--- a/app/code/Svea/Maksuturva/view/frontend/web/js/action/select-payment-method.js
+++ b/app/code/Svea/Maksuturva/view/frontend/web/js/action/select-payment-method.js
@@ -1,25 +1,30 @@
 define(
     [
+        'jquery',
         'Magento_Checkout/js/model/quote',
         'Magento_Checkout/js/model/full-screen-loader',
-        'jquery',
         'Magento_Checkout/js/action/get-totals',
     ],
-    function (quote, fullScreenLoader, jQuery, getTotalsAction) {
+    function ($, quote, fullScreenLoader, getTotalsAction) {
         'use strict';
         return function (paymentMethod) {
             quote.paymentMethod(paymentMethod);
 
             fullScreenLoader.startLoader();
 
-            jQuery.ajax('/maksuturva/checkout/applyPaymentMethod', {
-                data: {payment_method: paymentMethod},
+            let data = {
+                payment_method: paymentMethod.method,
+                sub_payment_method: paymentMethod?.extension_attributes?.maksuturva_preselected_payment_method,
+                collated_method: paymentMethod?.extension_attributes?.collated_method
+            };
+
+            $.ajax('/maksuturva/checkout/applyPaymentMethod', {
+                data: data,
                 complete: function () {
                     getTotalsAction([]);
                     fullScreenLoader.stopLoader();
                 }
             });
-
         }
     }
 );

--- a/app/code/Svea/Maksuturva/view/frontend/web/js/view/payment/method-renderer/maksuturva_payment.js
+++ b/app/code/Svea/Maksuturva/view/frontend/web/js/view/payment/method-renderer/maksuturva_payment.js
@@ -15,7 +15,7 @@ define(
         'Magento_Checkout/js/action/get-totals',
         'mage/validation'
     ],
-    function ($, ko, Component, selectPaymentMethodAction,quote, checkoutData, urlBuilder, url,customer, additionalValidators, placeOrderAction, fullScreenLoader, getTotalsAction) {
+    function ($, ko, Component, selectPaymentMethodAction, quote, checkoutData, urlBuilder, url,customer, additionalValidators, placeOrderAction, fullScreenLoader, getTotalsAction) {
         'use strict';
 
         var selectedMethod = ko.observable();
@@ -287,9 +287,11 @@ define(
             getData: function () {
                 return {
                     "method": this.item.method,
-                    "extension_attributes": {maksuturva_preselected_payment_method : this.selectedPayment()}
+                    "extension_attributes": {
+                        maksuturva_preselected_payment_method : this.selectedPayment(),
+                        collated_method : this.collatedMethod,
+                    }
                 };
-
             },
             placeOrder: function (data, event) {
                 if (event) {
@@ -330,9 +332,11 @@ define(
             },
 
             selectedPayment: selectedMethod,
+            collatedMethod: null,
 
             selectSubMethod : function (data, event){
                 this.selectedPayment(event.target.value);
+                this.updateTotals();
                 return true;
             },
 
@@ -341,18 +345,8 @@ define(
                 return window.checkoutConfig.payment[this.getCode()]['preselectRequired'];
             },
 
-            updateTotals: function (parentPaymentMethod, subpaymentMethod) {
-                fullScreenLoader.startLoader();
-                jQuery.ajax('/maksuturva/checkout/applyPaymentMethod', {
-                    data: {
-                        payment_method: parentPaymentMethod,
-                        collated_method: subpaymentMethod
-                    },
-                    complete: function () {
-                        getTotalsAction([]);
-                        fullScreenLoader.stopLoader();
-                    }
-                });
+            updateTotals: function () {
+                selectPaymentMethodAction(this.getData());
             }
         });
     }

--- a/app/code/Svea/MaksuturvaCollated/etc/extension_attributes.xml
+++ b/app/code/Svea/MaksuturvaCollated/etc/extension_attributes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
+    <extension_attributes for="Magento\Quote\Api\Data\PaymentInterface">
+        <attribute code="collated_method" type="string" />
+    </extension_attributes>
+</config>

--- a/app/code/Svea/MaksuturvaCollated/view/frontend/web/js/view/payment/method-renderer/maksuturva-collated-method.js
+++ b/app/code/Svea/MaksuturvaCollated/view/frontend/web/js/view/payment/method-renderer/maksuturva-collated-method.js
@@ -24,7 +24,6 @@ define(
             title_pay_bank: window.checkoutConfig.payment[bank_method_code]['title'],
             payments_pay_bank: window.checkoutConfig.payment[bank_method_code]['methods'],
 
-
             defaults: {
                 template: window.checkoutConfig.payment[method_code]['template'],
             },
@@ -42,10 +41,9 @@ define(
                 return bank_method_code;
             },
             selectSubMethod: function (data, event){
+                this.collatedMethod = data.parentMethod;
                 this.selectedPayment(event.target.value);
-                if (data.parentMethod) {
-                    this.updateTotals('maksuturva_collated_payment', data.parentMethod);
-                }
+                this.updateTotals();
                 return true;
             }
         });

--- a/app/code/Svea/MaksuturvaCollated/view/frontend/web/template/payment/icons_form_collated.html
+++ b/app/code/Svea/MaksuturvaCollated/view/frontend/web/template/payment/icons_form_collated.html
@@ -9,7 +9,6 @@
         </label>
 
     </div>
-
     <div class="payment-method-content">
         <!-- ko foreach: getRegion('messages') -->
         <!-- ko template: getTemplate() --><!-- /ko -->
@@ -24,21 +23,21 @@
         </div>
         <!-- ko if: payments_pay_later -->
         <span class="subpayment-title" data-bind="text: title_pay_later"></span>
-        <form data-bind="attr: {id: getLaterCode() +'-form'}, data-role: getLaterCode() + '-form'" class="form form-purchase-order" >
-            <div class="maksuturva-payment-methods" data-bind="attr: {id: 'payment_form_'+ getLaterCode()}">
+        <form data-bind="attr: {id: getLaterCode() +'-form-collated'}, data-role: getLaterCode() + '-form-collated'" class="form form-purchase-order" >
+            <div class="maksuturva-payment-methods" data-bind="attr: {id: 'collated_payment_form_'+ getLaterCode()}">
                 <!-- ko foreach: { data: payments_pay_later, as: 'subpayment' } -->
                 <div class="payment-method">
                     <input class="payment-method-radio"
                         type="radio"
                         data-bind="
-                            attr: { id: 'maksuturva_' + subpayment.code, name: 'maksuturva_' + subpayment.code },
+                            attr: { id: 'maksuturva_collated_' + subpayment.code, name: 'maksuturva_collated_' + subpayment.code },
                             value:subpayment.code,
                             checked: $parent.selectedPayment,
                             event:{ click: $parent.selectSubMethod.bind($parent)}
                         "
                         tabindex="0"
                         data-validate="{required:true}">
-                    <label class="payment-method-label" data-bind="attr: {for: 'maksuturva_' + subpayment.code}">
+                    <label class="payment-method-label" data-bind="attr: {for: 'maksuturva_collated_' + subpayment.code}">
                         <img data-bind="attr: {src: subpayment.imageurl, alt: subpayment.displayname} "/>
                     </label>
                 </div>
@@ -48,21 +47,21 @@
         <!--/ko-->
         <!-- ko if: payments_pay_other -->
         <span class="subpayment-title" data-bind="text: title_pay_other"></span>
-        <form data-bind="attr: {id: getOtherCode() +'-form'}, data-role: getOtherCode() + '-form'" class="form form-purchase-order" >
-            <div class="maksuturva-payment-methods" data-bind="attr: {id: 'payment_form_'+ getOtherCode()}">
+        <form data-bind="attr: {id: getOtherCode() +'-form-collated'}, data-role: getOtherCode() + '-form-collated'" class="form form-purchase-order" >
+            <div class="maksuturva-payment-methods" data-bind="attr: {id: 'collated_payment_form_'+ getOtherCode()}">
                 <!-- ko foreach: { data: payments_pay_other, as: 'subpayment' } -->
                 <div class="payment-method">
                     <input class="payment-method-radio"
                            type="radio"
                            data-bind="
-                            attr: { id: 'maksuturva_' + subpayment.code, name: 'maksuturva_' + subpayment.code },
+                            attr: { id: 'maksuturva_collated_' + subpayment.code, name: 'maksuturva_collated_' + subpayment.code },
                             value:subpayment.code,
                             checked: $parent.selectedPayment,
                             event:{ click: $parent.selectSubMethod.bind($parent)}
                         "
                            tabindex="0"
                            data-validate="{required:true}">
-                    <label class="payment-method-label" data-bind="attr: {for: 'maksuturva_' + subpayment.code}">
+                    <label class="payment-method-label" data-bind="attr: {for: 'maksuturva_collated_' + subpayment.code}">
                         <img data-bind="attr: {src: subpayment.imageurl, alt: subpayment.displayname} "/>
                     </label>
                 </div>
@@ -72,21 +71,21 @@
         <!--/ko-->
         <!-- ko if: payments_pay_bank -->
         <span class="subpayment-title" data-bind="text: title_pay_bank"></span>
-        <form data-bind="attr: {id: getCode() +'-form'}, data-role: getCode() + '-form'" class="form form-purchase-order" >
-            <div class="maksuturva-payment-methods" data-bind="attr: {id: 'payment_form_'+ getCode()}">
+        <form data-bind="attr: {id: getCode() +'-form-collated'}, data-role: getCode() + '-form-collated'" class="form form-purchase-order" >
+            <div class="maksuturva-payment-methods" data-bind="attr: {id: 'collated_payment_form_'+ getCode()}">
                 <!-- ko foreach: { data: payments_pay_bank, as: 'subpayment' } -->
                 <div class="payment-method">
                     <input class="payment-method-radio"
                            type="radio"
                            data-bind="
-                            attr: { id: 'maksuturva_' + subpayment.code, name: 'maksuturva_' + subpayment.code },
+                            attr: { id: 'maksuturva_collated_' + subpayment.code, name: 'maksuturva_collated_' + subpayment.code },
                             value:subpayment.code,
                             checked: $parent.selectedPayment,
                             event:{ click: $parent.selectSubMethod.bind($parent)}
                         "
                            tabindex="0"
                            data-validate="{required:true}">
-                    <label class="payment-method-label" data-bind="attr: {for: 'maksuturva_' + subpayment.code}">
+                    <label class="payment-method-label" data-bind="attr: {for: 'maksuturva_collated_' + subpayment.code}">
                         <img data-bind="attr: {src: subpayment.imageurl, alt: subpayment.displayname} "/>
                     </label>
                 </div>


### PR DESCRIPTION
Added support for defining handling fees for each submethod under each payment method including Collated.

For example, with "10;FI01=5;FI06=7.5" the fee in quote gets resolved based on selected method in a following way:

- FI01 gets a fee of 5
- FI06 gets a fee of 7.5
- Other methods in that group get a fee of 10