### PR TITLE
Add support for Magento tax and discount configurations

### DIFF
--- a/app/code/Svea/Maksuturva/Model/Gateway/Total/TotalCalculation.php
+++ b/app/code/Svea/Maksuturva/Model/Gateway/Total/TotalCalculation.php
@@ -7,8 +7,7 @@ use Magento\Sales\Api\Data\OrderInterface;
 class TotalCalculation
 {
     /**
-     * Get order total including tax but without shipping price and tax and handling fee.
-     * Discount are included in the total
+     * Get the order total including tax and discounts, but without shipping price, shipping tax and handling fee.
      *
      * @param OrderInterface $order
      * @return float
@@ -29,14 +28,11 @@ class TotalCalculation
      */
     public function getDiscountAmount($order)
     {
-        // By tax compensated discount we mean the value which is
-        // actually subtracted from the total to get the correct total for
-        // the order, and not the value provided by Magentos base_discount_amount
-        // because it may change depending on the configuration at which
-        // point the discounts are calculated (before / after tax)
+        // By tax compensated discount we mean the value which is actually subtracted from the subtotal to get the correct total for
+        // the order, and not the value provided by Magentos base_discount_amount because it may change depending on the configuration at which
+        // point the discounts and taxes are calculated
 
-        // Start from productsTotal which has only the real prices for products
-        // discounts etc. applied
+        // Start from productsTotal which has only the real prices for products, discounts etc. applied
         return  $this->getProductsTotal($order)
 
             // Subtract the products normal price from the total to get negative discount amount.

--- a/app/code/Svea/Maksuturva/Model/Gateway/Total/TotalCalculation.php
+++ b/app/code/Svea/Maksuturva/Model/Gateway/Total/TotalCalculation.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Svea\Maksuturva\Model\Gateway\Total;
+
+use Magento\Sales\Api\Data\OrderInterface;
+
+class TotalCalculation
+{
+    /**
+     * Get order total including tax but without shipping price and tax and handling fee.
+     * Discount are included in the total
+     *
+     * @param OrderInterface $order
+     * @return float
+     */
+    public function getProductsTotal($order)
+    {
+        return $order->getBaseGrandTotal()
+            - $order->getBaseShippingAmount()
+            - $order->getBaseShippingTaxAmount()
+            - $order->getHandlingFee();
+    }
+
+    /**
+     * Get tax compensated discount amount regardless of Magento configuration
+     *
+     * @param OrderInterface $order
+     * @return float
+     */
+    public function getDiscountAmount($order)
+    {
+        // By tax compensated discount we mean the value which is
+        // actually subtracted from the total to get the correct total for
+        // the order, and not the value provided by Magentos base_discount_amount
+        // because it may change depending on the configuration at which
+        // point the discounts are calculated (before / after tax)
+
+        // Start from productsTotal which has only the real prices for products
+        // discounts etc. applied
+        return  $this->getProductsTotal($order)
+
+            // Subtract the products normal price from the total to get negative discount amount.
+            - $order->getBaseSubtotalInclTax()
+
+            // Add the gift card discount back because it is added as a separate discount row
+            + $this->getGiftCardAmount($order);
+    }
+
+    /**
+     * Get the gift card amount from order as a positive number
+     *
+     * @param OrderInterface $order
+     *
+     * @return float
+     */
+    private function getGiftCardAmount($order)
+    {
+        $orderData = $order->getData();
+
+        if (isset($orderData["base_gift_cards_amount"]) && $orderData["base_gift_cards_amount"] != 0) {
+            return abs((float)$orderData["base_gift_cards_amount"]);
+        }
+
+        return 0.0;
+    }
+}

--- a/app/code/Svea/Maksuturva/Model/Observer/AddGiftCardPaymentRow.php
+++ b/app/code/Svea/Maksuturva/Model/Observer/AddGiftCardPaymentRow.php
@@ -21,6 +21,11 @@ class AddGiftCardPaymentRow implements ObserverInterface
         if (isset($orderData["base_gift_cards_amount"]) && $orderData["base_gift_cards_amount"] != 0) {
             $discount = (float)$orderData["base_gift_cards_amount"];
 
+            // Always have the discount as a negative number
+            if ($discount > 0) {
+                $discount = -$discount;
+            }
+
             $row = array(
                 'pmt_row_name' => "Gift cards",
                 'pmt_row_desc' => "Gift cards",
@@ -40,10 +45,12 @@ class AddGiftCardPaymentRow implements ObserverInterface
                 'pmt_row_type' => 6, // discounts
             );
 
-            $totalAmount = $this->getTotalAmount($options);
-            $totalAmount = $discount > 0 ? ($totalAmount - $discount) : ($totalAmount + $discount);
-
-            $options["pmt_amount"] = str_replace('.', ',', sprintf("%.2f", $totalAmount));
+            // Modifying the total is commented out because the discounts are already included in the total at this point.
+            // See the implementation in Model\Gateway\Total\TotalCalculation::getProductsTotal()
+            //
+            // $totalAmount = $this->getTotalAmount($options);
+            // $totalAmount = $discount > 0 ? ($totalAmount - $discount) : ($totalAmount + $discount);
+            // options["pmt_amount"] = str_replace('.', ',', sprintf("%.2f", $totalAmount));
 
             array_push($options["pmt_rows_data"], $row);
             $options["pmt_rows"] = count($options["pmt_rows_data"]);


### PR DESCRIPTION
This pull request introduces changes to the module which add the support for various tax and discount configurations in Magento.

Summary of changes

**1. Removing totalAmount calculation**

The custom totalAmount calculation from Svea\Maksuturva\Model\Gateway\Implementation::getForm() was removed and replaced with Total\TotalCalculation::getProductsTotal() where the total is coming from Magento and it automatically respects all tax and discount configurations. From orders grand total we need to subtract only the things we need separately EXCEPT discounts. Discounts should be included in the productsTotal amount.

**2. Refactoring discount calculation**

Discounts use a custom calculation implemented in Total\TotalCalculation::getDiscountAmount(). The discount amount is 'tax compensated' so it also respects Magentos discount configurations automatically. The logic is based on productsTotal and orders subtotal. That's how we can calculate the discount amount without worrying about configurations so pmt_amount and pmt_sellercosts with discount rows always match the real total of the order.

**3. Removing total calculation logic from gift card row**

Gift cards are added as a separate row in Svea\Maksuturva\Observer\AddGiftCardPaymentRow. The logic is the same as before but the total is not modified in the observer because the total already includes all discounts.

**4. Making sure gift card amount is always negative**

Gift card amount has to be sent as a negative number so there was an additional logic added to the observer which makes the discount always negative even if the discount comes as a positive number from Magento.