### PR TITLE
MAKSU-209 PHP8.1 support

### DIFF
--- a/app/code/Svea/Maksuturva/Model/Config/Config.php
+++ b/app/code/Svea/Maksuturva/Model/Config/Config.php
@@ -216,6 +216,9 @@ class Config
     {
         $formatted = [];
         foreach ($value as $key => $data) {
+            if ($data === null) {
+                continue;
+            }
             $entries = [];
             foreach (\explode(';', $data) as $entry) {
                 $feeInfo = \explode('=', $entry);

--- a/app/code/Svea/Maksuturva/Model/Creditmemo/Total/HandlingFee.php
+++ b/app/code/Svea/Maksuturva/Model/Creditmemo/Total/HandlingFee.php
@@ -15,7 +15,7 @@ class HandlingFee extends AbstractTotal
         $order = $creditmemo->getOrder();
         $orderHandlingFee = $order->getHandlingFee();
         $allowedAmount = $orderHandlingFee - $order->getRefundedHandlingFee();
-        $desiredAmount = round($creditmemo->getBaseHandlingFee(), 2);
+        $desiredAmount = round($creditmemo->getBaseHandlingFee() ?? 0, 2);
 
         // Note: ($x > $y + 0.0001) means ($x >= $y) for floats
         if ($desiredAmount > round($allowedAmount) + 0.0001) {

--- a/app/code/Svea/Maksuturva/Model/Form.php
+++ b/app/code/Svea/Maksuturva/Model/Form.php
@@ -185,6 +185,10 @@ class Form extends \Magento\Framework\Model\AbstractModel implements \Svea\Maksu
 
         // Force to cut off all amps and merge in current array_data
         foreach ($data as $key => $value) {
+            if ($value === null) {
+                $this->_formData[$key] = $value;
+                continue;
+            }
             if ($key == 'pmt_rows_data') {
                 $rows = array();
                 foreach ($value as $k => $v) {
@@ -486,6 +490,9 @@ class Form extends \Magento\Framework\Model\AbstractModel implements \Svea\Maksu
 
     private function convert_encoding($string_input, $encoding)
     {
+        if ($encoding === null) {
+            $encoding = $this->_charsethttp;
+        }
         return mb_convert_encoding($string_input, $encoding);
     }
 
@@ -512,6 +519,10 @@ class Form extends \Magento\Framework\Model\AbstractModel implements \Svea\Maksu
 
         // Force to cut off all amps and merge in current array_data
         foreach ($data as $key => $value) {
+            if ($value === null) {
+                $this->_formData[$key] = $value;
+                continue;
+            }
             if ($key == 'pmt_rows_data') {
                 $rows = array();
                 foreach ($value as $k => $v) {

--- a/app/code/Svea/Maksuturva/Model/Observer/PaymentMethodIsActive.php
+++ b/app/code/Svea/Maksuturva/Model/Observer/PaymentMethodIsActive.php
@@ -2,6 +2,7 @@
 namespace Svea\Maksuturva\Model\Observer;
 
 use Magento\Framework\Event\ObserverInterface;
+use Svea\Maksuturva\Model\PaymentAbstract;
 
 class PaymentMethodIsActive implements ObserverInterface {
 
@@ -15,7 +16,7 @@ class PaymentMethodIsActive implements ObserverInterface {
         $event  = $observer->getEvent();
         $method = $event->getMethodInstance();
 
-        if ($method instanceof PaymentAbstract) {    
+        if ($method instanceof PaymentAbstract) {
             $result = $event->getResult();
             if (is_object($method)) {
                 $methodCode = $method->getCode();

--- a/app/code/Svea/Maksuturva/etc/csp_whitelist.xml
+++ b/app/code/Svea/Maksuturva/etc/csp_whitelist.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp/etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="connect-src">
+            <values>
+                <value id="test1.maksuturva.fi" type="host">https://test1.maksuturva.fi/</value>
+            </values>
+        </policy>
+        <policy id="img-src">
+            <values>
+                <value id="https://www.maksuturva.fi/" type="host">https://www.maksuturva.fi/</value>
+                <value id="test1.maksuturva.fi" type="host">https://test1.maksuturva.fi/</value>
+                <value id="https://payments.maksuturva.fi/" type="host">https://payments.maksuturva.fi/</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>

--- a/app/code/Svea/MaksuturvaCard/Model/Card.php
+++ b/app/code/Svea/MaksuturvaCard/Model/Card.php
@@ -12,7 +12,8 @@ class Card extends \Svea\Maksuturva\Model\PaymentAbstract
             $this->_methods = $this->_getPaymentMethods();
         }
         foreach($this->_methods as $method){
-            if(in_array($method->code, $this->_getAllowedMethods())){
+            $allowedMethods = $this->_getAllowedMethods();
+            if(in_array($method->code, $allowedMethods)){
                 $this->_allowedMethods[] = $method;
             }
         }


### PR DESCRIPTION
- Several classes fixed to avoid php8.1 crashes. 
- Added csp_whitelist for maksuturva URLs.
- Definition of Svea\Maksuturva\Model\PaymentAbstract class added to Svea/Maksuturva/Model/Observer/PaymentMethodIsActive so now class functionality works again.