### PR TITLE
Change SKU length

### DIFF
--- a/app/code/Svea/Maksuturva/Model/Gateway/Implementation.php
+++ b/app/code/Svea/Maksuturva/Model/Gateway/Implementation.php
@@ -1,6 +1,8 @@
 <?php
 namespace Svea\Maksuturva\Model\Gateway;
 
+use Magento\Bundle\Model\Product\Type;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Payment\Model\InfoInterface;
 use Magento\Sales\Api\Data\InvoiceInterface;
@@ -118,88 +120,9 @@ class Implementation extends \Svea\Maksuturva\Model\Gateway\Base
             $items = $order->getAllItems();
             $orderData = $order->getData();
             $totalSellerCosts = 0;
-            $products_rows = array();
 
-            foreach ($items as $itemId => $item) {
-                $itemData = $item->getData();
-                $productName = $item->getName();
-
-                $sku = $item->getSku();
-                if (mb_strlen($sku) > 10) {
-                    $sku = mb_substr($sku, 0, 10);
-                }
-
-                $row = array(
-                    'pmt_row_name' => $productName,
-                    'pmt_row_desc' => $sku,
-                    'pmt_row_quantity' => str_replace('.', ',', sprintf("%.2f", $item->getQtyToInvoice())),
-                    'pmt_row_articlenr' => $sku,
-                    'pmt_row_deliverydate' => date("d.m.Y"),
-                    'pmt_row_price_net' => str_replace('.', ',', sprintf("%.2f", $item->getBasePrice())),
-                    'pmt_row_vat' => str_replace('.', ',', sprintf("%.2f", $itemData["tax_percent"])),
-                    'pmt_row_discountpercentage' => "0,00",
-                    'pmt_row_type' => 1,
-                );
-
-                if ($item->getProductType() == \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE && $item->getChildrenItems() != null && sizeof($item->getChildrenItems()) > 0) {
-                    $children = $item->getChildrenItems();
-
-                    if (sizeof($children) != 1) {
-                        \error_log("Svea Payments module FAIL: more than one children for configurable product!");
-                        continue;
-                    }
-
-                    if (in_array($items[$itemId + 1], $children) == false) {
-                        \error_log("Svea Payments module FAIL: No children in order!");
-                        continue;
-                    }
-
-                    $child = $children[0];
-                    $row['pmt_row_name'] = $child->getName();
-                    $childSku = $child->getSku();
-
-                    if (strlen($childSku) > 0) {
-                        if (mb_strlen($childSku) > 10) {
-                            $childSku = mb_substr($childSku, 0, 10);
-                        }
-                        $row['pmt_row_articlenr'] = $childSku;
-                    }
-                    if (strlen($childSku) > 0) {
-                        $row['pmt_row_desc'] = $childSku;
-                    }
-                }
-
-                else if ($item->getParentItem() != null && $item->getParentItem()->getProductType() == \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE) {
-                    continue;
-                }
-
-                else if ($item->getProductType() == \Magento\Bundle\Model\Product\Type::TYPE_CODE && $item->getChildrenItems() != null && sizeof($item->getChildrenItems()) > 0) {
-                    $row['pmt_row_quantity'] = str_replace('.', ',', sprintf("%.2f", $item->getQtyOrdered()));
-                    if ($item->getProduct()->getPriceType() == 0) { //if price is fully dynamic
-                        $row['pmt_row_price_net'] = str_replace('.', ',', sprintf("%.2f", '0'));
-                    }
-                    $row['pmt_row_type'] = 4;
-                }
-
-                else if ($item->getParentItem() != null && $item->getParentItem()->getProductType() == \Magento\Bundle\Model\Product\Type::TYPE_CODE) {
-                    $parentQty = $item->getParentItem()->getQtyOrdered();
-
-                    if (intval($parentQty, 10) == $parentQty) {
-                        $parentQty = intval($parentQty, 10);
-                    }
-
-                    $unitQty = $item->getQtyOrdered() / $parentQty;
-
-                    if (intval($unitQty, 10) == $unitQty) {
-                        $unitQty = intval($unitQty, 10);
-                    }
-
-                    $row['pmt_row_name'] = $unitQty . " X " . $parentQty . " X " . $item->getName();
-                    $row['pmt_row_quantity'] = str_replace('.', ',', sprintf("%.2f", $item->getQtyOrdered()));
-                    $row['pmt_row_type'] = 4;
-                }
-                array_push($products_rows, $row);
-            }
+            // Prepare product rows
+            $products_rows = $this->prepareProductRows($items);
 
             // row type 6
             if (isset($orderData["base_discount_amount"]) && $orderData["base_discount_amount"] != 0) {
@@ -945,5 +868,92 @@ class Implementation extends \Svea\Maksuturva\Model\Gateway\Base
     {
         $this->payment = $payment;
         return $this;
+    }
+
+    /**
+     * @param array $items
+     * @return array
+     */
+    public function prepareProductRows(array $items)
+    {
+        $products_rows = [];
+
+        foreach ($items as $itemId => $item) {
+            $itemData = $item->getData();
+            $productName = $item->getName();
+
+            $sku = $item->getSku();
+            if (mb_strlen($sku) > 10) {
+                $sku = mb_substr($sku, 0, 10);
+            }
+
+            $row = array(
+                'pmt_row_name' => $productName,
+                'pmt_row_desc' => $sku,
+                'pmt_row_quantity' => str_replace('.', ',', sprintf("%.2f", $item->getQtyToInvoice())),
+                'pmt_row_articlenr' => $sku,
+                'pmt_row_deliverydate' => date("d.m.Y"),
+                'pmt_row_price_net' => str_replace('.', ',', sprintf("%.2f", $item->getBasePrice())),
+                'pmt_row_vat' => str_replace('.', ',', sprintf("%.2f", $itemData["tax_percent"])),
+                'pmt_row_discountpercentage' => "0,00",
+                'pmt_row_type' => 1,
+            );
+
+            if ($item->getProductType() == Configurable::TYPE_CODE && $item->getChildrenItems() != null && sizeof($item->getChildrenItems()) > 0) {
+                $children = $item->getChildrenItems();
+
+                if (sizeof($children) != 1) {
+                    \error_log("Svea Payments module FAIL: more than one children for configurable product!");
+                    continue;
+                }
+
+                if (!in_array($items[$itemId + 1], $children)) {
+                    \error_log("Svea Payments module FAIL: No children in order!");
+                    continue;
+                }
+
+                $child = $children[0];
+                $row['pmt_row_name'] = $child->getName();
+                $childSku = $child->getSku();
+
+                if (strlen($childSku) > 0) {
+                    if (mb_strlen($childSku) > 10) {
+                        $childSku = mb_substr($childSku, 0, 10);
+                    }
+                    $row['pmt_row_articlenr'] = $childSku;
+                }
+                if (strlen($childSku) > 0) {
+                    $row['pmt_row_desc'] = $childSku;
+                }
+            } else if ($item->getParentItem() != null && $item->getParentItem()->getProductType() == Configurable::TYPE_CODE) {
+                continue;
+            } else if ($item->getProductType() == Type::TYPE_CODE && $item->getChildrenItems() != null && sizeof($item->getChildrenItems()) > 0) {
+                $row['pmt_row_quantity'] = str_replace('.', ',', sprintf("%.2f", $item->getQtyOrdered()));
+                if ($item->getProduct()->getPriceType() == 0) { //if price is fully dynamic
+                    $row['pmt_row_price_net'] = str_replace('.', ',', sprintf("%.2f", '0'));
+                }
+                $row['pmt_row_type'] = 4;
+            } else if ($item->getParentItem() != null && $item->getParentItem()->getProductType() == Type::TYPE_CODE) {
+                $parentQty = $item->getParentItem()->getQtyOrdered();
+
+                if (intval($parentQty, 10) == $parentQty) {
+                    $parentQty = intval($parentQty, 10);
+                }
+
+                $unitQty = $item->getQtyOrdered() / $parentQty;
+
+                if (intval($unitQty, 10) == $unitQty) {
+                    $unitQty = intval($unitQty, 10);
+                }
+
+                $row['pmt_row_name'] = $unitQty . " X " . $parentQty . " X " . $item->getName();
+                $row['pmt_row_quantity'] = str_replace('.', ',', sprintf("%.2f", $item->getQtyOrdered()));
+                $row['pmt_row_type'] = 4;
+            }
+
+            $products_rows[] = $row;
+        }
+
+        return $products_rows;
     }
 }

--- a/app/code/Svea/Maksuturva/Model/Gateway/Implementation.php
+++ b/app/code/Svea/Maksuturva/Model/Gateway/Implementation.php
@@ -881,17 +881,13 @@ class Implementation extends \Svea\Maksuturva\Model\Gateway\Base
         foreach ($items as $itemId => $item) {
             $itemData = $item->getData();
             $productName = $item->getName();
-
-            $sku = $item->getSku();
-            if (mb_strlen($sku) > 10) {
-                $sku = mb_substr($sku, 0, 10);
-            }
+            $sku = $item->getSku() ?? '';
 
             $row = array(
                 'pmt_row_name' => $productName,
-                'pmt_row_desc' => $sku,
+                'pmt_row_desc' => mb_substr($sku, 0, 1000),
                 'pmt_row_quantity' => str_replace('.', ',', sprintf("%.2f", $item->getQtyToInvoice())),
-                'pmt_row_articlenr' => $sku,
+                'pmt_row_articlenr' => mb_substr($sku, 0, 100),
                 'pmt_row_deliverydate' => date("d.m.Y"),
                 'pmt_row_price_net' => str_replace('.', ',', sprintf("%.2f", $item->getBasePrice())),
                 'pmt_row_vat' => str_replace('.', ',', sprintf("%.2f", $itemData["tax_percent"])),
@@ -914,17 +910,9 @@ class Implementation extends \Svea\Maksuturva\Model\Gateway\Base
 
                 $child = $children[0];
                 $row['pmt_row_name'] = $child->getName();
-                $childSku = $child->getSku();
-
-                if (strlen($childSku) > 0) {
-                    if (mb_strlen($childSku) > 10) {
-                        $childSku = mb_substr($childSku, 0, 10);
-                    }
-                    $row['pmt_row_articlenr'] = $childSku;
-                }
-                if (strlen($childSku) > 0) {
-                    $row['pmt_row_desc'] = $childSku;
-                }
+                $childSku = $child->getSku() ?? '';
+                $row['pmt_row_articlenr'] = mb_substr($childSku, 0, 100);
+                $row['pmt_row_desc'] = mb_substr($childSku, 0, 1000);
             } else if ($item->getParentItem() != null && $item->getParentItem()->getProductType() == Configurable::TYPE_CODE) {
                 continue;
             } else if ($item->getProductType() == Type::TYPE_CODE && $item->getChildrenItems() != null && sizeof($item->getChildrenItems()) > 0) {


### PR DESCRIPTION
I had a case where product data had some sensitive information which needed to be altered before sending data to payment service. Altering that data was done using event "maksuturva_gateway_implementation_get_form_after" but the problem there was that in case SKU was longer than 10 characters I couldn't use that data to fetch rest of the product data. So I did small refactor and updated the limits to match the [Svea documentation](https://sveapayments.atlassian.net/wiki/spaces/DOCS/pages/1657012476/Create+Payment).