### PR TITLE
Fix creating order from admin

### DIFF
--- a/app/code/Svea/Maksuturva/Model/PaymentAbstract.php
+++ b/app/code/Svea/Maksuturva/Model/PaymentAbstract.php
@@ -177,7 +177,7 @@ abstract class PaymentAbstract extends \Magento\Payment\Model\Method\AbstractMet
 
     protected function _getPaymentMethods()
     {
-        $quoteTotal = $this->cart->getQuote()->getGrandTotal();
+        $quoteTotal = $this->cart->getQuote()->getGrandTotal() ?? 0;
         $cacheKey = "MAKSUTURVA_PAYMENT_METHODS_" . number_format($quoteTotal, 4, "_", "");
 
         if ($cachedData = $this->cache->load($cacheKey)) {


### PR DESCRIPTION
Creating order from admin gives following error

`1 exception(s):
Exception #0 (Exception): Deprecated Functionality: number_format(): Passing null to parameter #1 ($num) of type float is deprecated in app/code/Svea/Maksuturva/Model/PaymentAbstract.php on line 181`

This is caused because php7.4 allowed passing null value for number_format() and php8.1 requires float.